### PR TITLE
Update Neat.completions to not trim the contents

### DIFF
--- a/neat.sublime-completions
+++ b/neat.sublime-completions
@@ -18,16 +18,16 @@
  	{ "trigger": "reset-all", "contents": "@include reset-all;" },
 
  	// variables
- 	{ "trigger": "column", "contents": "$column: 90px;" },
- 	{ "trigger": "gutter", "contents": "$gutter: 30px;" },
- 	{ "trigger": "grid-columns", "contents": "$grid-columns: 8;" },
- 	{ "trigger": "max-width", "contents": "$max-width: 1024px;" },
- 	{ "trigger": "border-box-sizing", "contents": "$border-box-sizing: false;" },
- 	{ "trigger": "default-feature", "contents": "$default-feature: max-width;" },
- 	{ "trigger": "default-layout-direction", "contents": "$default-layout-direction: RTL;" },
- 	{ "trigger": "visual-grid", "contents": "$visual-grid: true;" },
- 	{ "trigger": "visual-grid-color", "contents": "$visual-grid-color: #FF0000;" },
- 	{ "trigger": "visual-grid-index", "contents": "$visual-grid-index: front;" },
- 	{ "trigger": "visual-grid-opacity", "contents": "$visual-grid-opacity: 0.7;" }
+ 	{ "trigger": "$column", "contents": "\\$column: 90px;" },
+ 	{ "trigger": "$gutter", "contents": "\\$gutter: 30px;" },
+ 	{ "trigger": "$grid-columns", "contents": "\\$grid-columns: 8;" },
+ 	{ "trigger": "$max-width", "contents": "\\$max-width: 1024px;" },
+ 	{ "trigger": "$border-box-sizing", "contents": "\\$border-box-sizing: false;" },
+ 	{ "trigger": "$default-feature", "contents": "\\$default-feature: max-width;" },
+ 	{ "trigger": "$default-layout-direction", "contents": "\\$default-layout-direction: RTL;" },
+ 	{ "trigger": "$visual-grid", "contents": "\\$visual-grid: true;" },
+ 	{ "trigger": "$visual-grid-color", "contents": "$\\visual-grid-color: #FF0000;" },
+ 	{ "trigger": "$visual-grid-index", "contents": "$\\visual-grid-index: front;" },
+ 	{ "trigger": "$visual-grid-opacity", "contents": "$\\visual-grid-opacity: 0.7;" }
   ]
 }


### PR DESCRIPTION
I first noticed that the variables were being trimmed when using max-width in a media query. 

I was typing max- and then hitting tab and all I was getting back was "width: 1024px;"

I also added $ to the variables so you could determine which trigger was what.
